### PR TITLE
test: enable storybook modes

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -9,6 +9,7 @@ const config: StorybookConfig = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/addon-interactions",
+    "storybook-i18n",
   ],
   framework: {
     name: "@storybook/vue3-vite",

--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -1,0 +1,39 @@
+type Viewport = "mobile" | "tablet" | "desktop";
+type Theme = "light" | "dark";
+type Locale = "de" | "en";
+
+const viewports: Viewport[] = ["mobile", "tablet", "desktop"];
+const themes: Theme[] = ["light", "dark"];
+const locales: Locale[] = ["de", "en"];
+
+/**
+ * All modes with different viewports
+ */
+export const allModes: Record<
+  string,
+  { viewport: Viewport; theme: Theme; locale: Locale }
+> = {};
+
+/**
+ * Modes for different themes and locales
+ */
+export const themeLocaleModes: Record<
+  string,
+  { theme: Theme; locale: Locale }
+> = {};
+
+let i = 1;
+let j = 1;
+
+for (const theme of themes) {
+  for (const locale of locales) {
+    themeLocaleModes[i++ + "-" + theme + "-" + locale] = { theme, locale };
+    for (const viewport of viewports) {
+      allModes[j++ + "-" + viewport + "-" + theme + "-" + locale] = {
+        viewport,
+        theme,
+        locale,
+      };
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "sass": "^1.68.0",
     "semantic-release": "^22.0.5",
     "storybook": "7.4.5",
+    "storybook-i18n": "^2.0.13",
     "typescript": "^5.2.2",
     "vite": "^4.4.9",
     "vite-plugin-dts": "^3.6.0",

--- a/vuetify-options.ts
+++ b/vuetify-options.ts
@@ -1,4 +1,4 @@
-import { VuetifyOptions } from "vuetify";
+import { type VuetifyOptions } from "vuetify";
 import { aliases, mdi } from "vuetify/iconsets/mdi-svg";
 
 const options: VuetifyOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10214,6 +10214,11 @@ store2@^2.14.2:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.14.2.tgz#56138d200f9fe5f582ad63bc2704dbc0e4a45068"
   integrity sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==
 
+storybook-i18n@^2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/storybook-i18n/-/storybook-i18n-2.0.13.tgz#e2172c9db06bd58a02a561edc508b19a989790bd"
+  integrity sha512-p0VPL5QiHdeS3W9BvV7UnuTKw7Mj1HWLW67LK0EOoh5fpSQIchu7byfrUUe1RbCF1gT0gOOhdNuTSXMoVVoTDw==
+
 storybook@7.4.5:
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.4.5.tgz#3456d2de3b28661b0a853c0ecbbdf2f6d695ac4f"


### PR DESCRIPTION
Enable storybook modes to check multiple themes and locales by default. Added additional modes to also check different viewports if necessary.