### PR TITLE
refactor: remove uppercase from buttons as default to fit md3-spec

### DIFF
--- a/vuetify-options.ts
+++ b/vuetify-options.ts
@@ -4,6 +4,11 @@ import { md3 } from "vuetify/blueprints";
 
 const options: VuetifyOptions = {
   blueprint: md3,
+  defaults: {
+    VBtn: {
+      class: "text-none",
+    },
+  },
   theme: {
     defaultTheme: "light",
     themes: {


### PR DESCRIPTION
Every button used in the stories will now per default not be in uppercase:

<img width="169" alt="image" src="https://github.com/Crystal-Creations-GbR/crystal-components/assets/32811389/9e98317a-2f02-4dc4-a4d2-8d98ff3f336e">
