### PR TITLE
Add properties to `CCard` and `CCardDialog`

### DIFF
--- a/src/components/CCard.vue
+++ b/src/components/CCard.vue
@@ -20,6 +20,20 @@
       ></v-progress-linear>
     </template>
 
+    <!-- Close button -->
+    <div
+      v-if="closable"
+      class="position-absolute pa-4 pa-md-6"
+      style="top: 0; right: 0"
+    >
+      <v-btn
+        :icon="mdiWindowClose"
+        variant="text"
+        color="black"
+        @click="emit('close')"
+      ></v-btn>
+    </div>
+
     <v-card-title
       v-if="title"
       class="pt-0 pb-0 px-6 px-md-8 text-h6"
@@ -91,6 +105,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, useSlots } from "vue";
 import { VCardText } from "vuetify/components";
+import { mdiWindowClose } from "@mdi/js";
 
 const slots = useSlots();
 
@@ -165,6 +180,13 @@ const props = withDefaults(
      * Applies specified color to the card - supports utility colors (for example `success` or `purple`) or css color (#033 or rgba(255, 0, 0, 0.5)).
      */
     color?: string;
+
+    /**
+     * If true, a close button will be added to the top right of the card.
+     *
+     * If this button is clicked, the `close` event is emitted.
+     */
+    closable?: boolean;
   }>(),
   {
     title: undefined,
@@ -243,6 +265,13 @@ onMounted(() => {
     contentScrollable.value = true;
   }
 });
+
+const emit = defineEmits<{
+  /**
+   * Event emitted when the close button is clicked.
+   */
+  (e: "close"): void;
+}>();
 </script>
 
 <style scoped lang="scss">

--- a/src/components/CCard.vue
+++ b/src/components/CCard.vue
@@ -143,6 +143,11 @@ const props = withDefaults(
     subtitle?: string;
 
     /**
+     * The mode how this `CCard` is used.
+     */
+    mode?: "default" | "bottom-sheet";
+
+    /**
      * Whether vertical padding should be applied to the content inside the card when the content is scrollable.
      *
      * Defaults to `true`.
@@ -194,6 +199,7 @@ const props = withDefaults(
     titleSize: "normal",
     wrapTitle: undefined,
     subtitle: undefined,
+    mode: "default",
     scrollingContentVerticalPadding: true,
     height: undefined,
     width: "100%",
@@ -208,16 +214,21 @@ const props = withDefaults(
 const cardTextComponent = ref<VCardText>();
 
 const cardClass = computed<string>(() => {
+  let classes = "";
+
+  if (props.mode === "bottom-sheet")
+    classes += " c-card--variant--bottom-sheet";
+
   if (
-    contentScrollable.value ||
-    slots["content-full-width"] ||
-    slots.actions ||
-    slots["prepend-actions"]
+    !contentScrollable.value &&
+    !slots["content-full-width"] &&
+    !slots.actions &&
+    !slots["prepend-actions"]
   ) {
-    return "";
+    classes += " pb-6 pb-md-8";
   }
 
-  return "pb-6 pb-md-8";
+  return classes;
 });
 
 /**
@@ -278,6 +289,11 @@ const emit = defineEmits<{
 @import "vuetify/lib/styles/settings/variables";
 
 .c-card {
+  &.c-card--variant--bottom-sheet {
+    border-bottom-left-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+  }
+
   & > .v-card-text > * {
     &:not(:last-child) {
       margin-bottom: 12px !important;

--- a/src/components/dialogs/CCardDialog.vue
+++ b/src/components/dialogs/CCardDialog.vue
@@ -3,6 +3,7 @@
     v-model="model"
     :width="width"
     :min-width="minWidth"
+    :height="height"
     :persistent="persistent"
     :activator="activator"
     class="c-dialog ma-2"
@@ -19,7 +20,9 @@
       :subtitle="subtitle"
       :loading="loading"
       :color="color"
+      :closable="closeButton"
       max-width=""
+      @close="model = false"
     >
       <template v-if="slots['prepend-actions']" #prepend-actions>
         <slot name="prepend-actions"></slot>
@@ -78,6 +81,11 @@ withDefaults(
     minWidth?: string;
 
     /**
+     * The height of the dialog
+     */
+    height?: string;
+
+    /**
      * Whether clicking outside the element or pressing esc key will close the dialog.
      */
     persistent?: boolean;
@@ -93,6 +101,11 @@ withDefaults(
     color?: string;
 
     /**
+     * If true, a close button will be added to the top right of the card which closes the dialog.
+     */
+    closeButton?: boolean;
+
+    /**
      * Explicitly sets the overlay’s activator.
      *
      * For more information, see https://vuetifyjs.com/en/api/v-dialog/.
@@ -105,6 +118,7 @@ withDefaults(
     subtitle: undefined,
     width: "500px",
     maxWidth: undefined,
+    height: undefined,
     minWidth: undefined,
     persistent: false,
     color: undefined,

--- a/stories/CCard.stories.ts
+++ b/stories/CCard.stories.ts
@@ -47,6 +47,9 @@ const meta: Meta<typeof CCard> = {
     color: {
       control: "text",
     },
+    closable: {
+      control: "boolean",
+    },
   },
   parameters: createComponentStorybookParameters({
     componentDescription:
@@ -159,6 +162,24 @@ export const Actions: Story = {
         <v-btn>Okay</v-btn>
       </template>
     `,
+  }),
+};
+
+export const Closable: Story = {
+  args: {
+    title: "Closable Card",
+    closable: true,
+  },
+  render: createStorybookRender({
+    components: { CCard },
+    template: `
+<c-card v-bind='args' class="ma-5">
+    Cards main content.
+</c-card>
+    `,
+  }),
+  parameters: createStorybookParameters({
+    slotTemplate: "Cards main content.",
   }),
 };
 

--- a/stories/CCard.stories.ts
+++ b/stories/CCard.stories.ts
@@ -23,6 +23,10 @@ const meta: Meta<typeof CCard> = {
     subtitle: {
       control: "text",
     },
+    mode: {
+      control: "radio",
+      options: ["default", "bottom-sheet"],
+    },
     scrollingContentVerticalPadding: {
       control: "boolean",
     },
@@ -169,6 +173,24 @@ export const Closable: Story = {
   args: {
     title: "Closable Card",
     closable: true,
+  },
+  render: createStorybookRender({
+    components: { CCard },
+    template: `
+<c-card v-bind='args' class="ma-5">
+    Cards main content.
+</c-card>
+    `,
+  }),
+  parameters: createStorybookParameters({
+    slotTemplate: "Cards main content.",
+  }),
+};
+
+export const BottomSheet: Story = {
+  args: {
+    title: "Card for a BottomSheet",
+    mode: "bottom-sheet",
   },
   render: createStorybookRender({
     components: { CCard },

--- a/stories/dialogs/CCardDialog.stories.ts
+++ b/stories/dialogs/CCardDialog.stories.ts
@@ -33,6 +33,9 @@ const meta: Meta<typeof CCardDialog> = {
     loading: {
       control: "boolean",
     },
+    closeButton: {
+      control: "boolean",
+    },
   },
   args: {
     modelValue: false,
@@ -246,6 +249,37 @@ export const ScrollableContent: Story = {
 
       <template #actions>
         <v-btn>Cancel</v-btn>
+        <v-btn>Okay</v-btn>
+      </template>
+    `,
+  }),
+};
+
+export const CloseButton: Story = {
+  args: {
+    title: "Dialog with a close button",
+    closeButton: true,
+  },
+  render: createStorybookRender({
+    components: { CCardDialog },
+    template: `
+      <div class="d-flex justify-center align-center">
+        <v-btn class="ma-4" @click='updateModel(true)' v-show="!chromatic">Show Dialog</v-btn>
+        <c-card-dialog v-bind='args' @update:modelValue='(val) => updateModel(val)'>
+          The content of the dialog.
+          
+          <template #actions>
+            <v-btn>Okay</v-btn>
+          </template>
+        </c-card-dialog>
+      </div>
+        `,
+  }),
+  parameters: createStorybookParameters({
+    slotTemplate: `
+      The content of the dialog.
+      
+      <template #actions>
         <v-btn>Okay</v-btn>
       </template>
     `,


### PR DESCRIPTION
The `closable` property introduces a known issue for long or center/end aligned titles, which will be fixed in the future: https://github.com/Crystal-Creations-GbR/crystal-components/issues/93